### PR TITLE
Use Glide instead of Picasso to increase Performance, available memory... etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
 #Similar Projects
 Similar libraries can be found [here](https://android-arsenal.com/tag/157)
 #Acknowledgements
-This library makes use of [Picasso](https://github.com/square/picasso) by Square Inc.
+This library makes use of [Glide](https://github.com/bumptech/glide) by Bumptech
 #License
 ```license
 Copyright 2015 Darshan Dorai

--- a/multipleimageselect/build.gradle
+++ b/multipleimageselect/build.gradle
@@ -21,5 +21,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:22.1.1'
-    compile 'com.squareup.picasso:picasso:2.5.2'
+    compile 'com.github.bumptech.glide:glide:3.6.0'
 }

--- a/multipleimageselect/src/main/java/com/darsh/multipleimageselect/adapters/CustomAlbumSelectAdapter.java
+++ b/multipleimageselect/src/main/java/com/darsh/multipleimageselect/adapters/CustomAlbumSelectAdapter.java
@@ -8,7 +8,7 @@ import android.widget.TextView;
 
 import com.darsh.multipleimageselect.R;
 import com.darsh.multipleimageselect.models.Album;
-import com.squareup.picasso.Picasso;
+import com.bumptech.glide.Glide;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -49,7 +49,7 @@ public class CustomAlbumSelectAdapter extends CustomGenericAdapter<Album> {
         Album album = getItem(position);
         viewHolder.textView.setText(album.name);
         File file = new File(album.imagePath);
-        Picasso.with(convertView.getContext()).load(file).fit().centerCrop().into(viewHolder.imageView);
+        Glide.with(convertView.getContext()).load(file).into(viewHolder.imageView);
 
         return convertView;
     }

--- a/multipleimageselect/src/main/java/com/darsh/multipleimageselect/adapters/CustomAlbumSelectAdapter.java
+++ b/multipleimageselect/src/main/java/com/darsh/multipleimageselect/adapters/CustomAlbumSelectAdapter.java
@@ -49,7 +49,7 @@ public class CustomAlbumSelectAdapter extends CustomGenericAdapter<Album> {
         Album album = getItem(position);
         viewHolder.textView.setText(album.name);
         File file = new File(album.imagePath);
-        Glide.with(convertView.getContext()).load(file).into(viewHolder.imageView);
+        Glide.with(convertView.getContext()).load(file).centerCrop().into(viewHolder.imageView);
 
         return convertView;
     }

--- a/multipleimageselect/src/main/java/com/darsh/multipleimageselect/adapters/CustomImageSelectAdapter.java
+++ b/multipleimageselect/src/main/java/com/darsh/multipleimageselect/adapters/CustomImageSelectAdapter.java
@@ -9,7 +9,7 @@ import android.widget.ImageView;
 
 import com.darsh.multipleimageselect.R;
 import com.darsh.multipleimageselect.models.Image;
-import com.squareup.picasso.Picasso;
+import com.bumptech.glide.Glide;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -52,7 +52,7 @@ public class CustomImageSelectAdapter extends CustomGenericAdapter<Image> {
         }
 
         File file = new File(arrayList.get(position).imagePath);
-        Picasso.with(context).load(file).placeholder(R.drawable.image_placeholder).fit().centerCrop().into(imageView);
+        Glide.with(context).load(file).placeholder(R.drawable.image_placeholder).centerCrop().into(imageView);
 
         return convertView;
     }


### PR DESCRIPTION
Picasso and Glide has almost same methods (especially method names!), but Glide use RGB_565 so save image memory.

check out this [document](http://inthecheesefactory.com/blog/get-to-know-glide-recommended-by-google/en) and publish new version.

thanks to nice library! 